### PR TITLE
Fix/cast values from string

### DIFF
--- a/src/homie-adapter.ts
+++ b/src/homie-adapter.ts
@@ -30,7 +30,9 @@ class HomieDevice extends Device {
       return;
     }
 
-    if (!propertyPart) {
+    // TODO: meta tags at property level are not verified right now and we can safely ignore this for now.
+    // Also ignoring meta tags here makes sure they are not added as ThingProperty either.
+    if (!propertyPart || propertyPart.startsWith('$')) {
       return;
     }
 

--- a/src/homie-adapter.ts
+++ b/src/homie-adapter.ts
@@ -56,7 +56,7 @@ class HomieDevice extends Device {
       property.update(keyPart, payload);
       this.adapter.handleDeviceAdded(this);
     } else {
-      property.setCachedValueAndNotify(payload);
+      property.castPayloadAndNotify(payload);
     }
   }
 }
@@ -64,6 +64,7 @@ class HomieDevice extends Device {
 class HomieProperty extends Property {
   constructor(device: Device, name: string, propertyDescr: {}, private setter: (value: any) => Promise<void>) {
     super(device, name, propertyDescr);
+    this.type = 'string';
   }
 
   public update(key: string, value: string) {
@@ -131,6 +132,30 @@ class HomieProperty extends Property {
         }
         break;
     }
+  }
+
+  public castPayloadAndNotify(payload: string) {
+    let castedPayload: any;
+    switch (this.type) {
+      case 'integer':
+      case 'number':
+        castedPayload = Number(payload);
+        break;
+      case 'boolean':
+        castedPayload = Boolean(payload);
+        break;
+      case 'string':
+      case 'enum':
+      case 'color':
+        castedPayload = payload;
+        break;
+      default:
+        console.warn(`Invalid type ${this.type}, falling back to string. Value arrived before type message.`);
+        castedPayload = payload;
+        break;
+    }
+
+    this.setCachedValueAndNotify(castedPayload);
   }
 
   async setValue(value: any): Promise<void> {


### PR DESCRIPTION
Hey there,

this PR incaludes two changes and affect #10 

1. make sure to cast the incoming value to its configured type, if it was configured earlier.
    - NOTE: The first incoming value is always stored as string. This is beacause MQTT orders the retained messages with the same QoS by subtypes (seperated by `/`). Less subtypes result in earlier handling of that message. All subsquent messages are handled accordingly to the configured type.
1. Since Node properties are not validated or set in any matter, we can ignore them for now. I noticed during testing that some of the node's properties were handled as if it were the containing value. This exposed internal information and cluttered the Thing with properties, the user is not interested in.
    - This is only  f771fd2 

To test this, just add a device with float values:

```
mosquitto_pub -t 'homie/device/$homie'-m '4.0'
mosquitto_pub -t 'homie/device/$state'-m 'ready'
mosquitto_pub -t 'homie/device/$name'-m 'Temperature'
mosquitto_pub -t 'homie/device/$nodes'-m 'temperature'
mosquitto_pub -t 'homie/device/temperature/$name'-m 'Temperature Node'
mosquitto_pub -t 'homie/device/temperature/$properties'-m 'temp,hum,p'
mosquitto_pub -t 'homie/device/temperature/temp'-m '23.79'
mosquitto_pub -t 'homie/device/temperature/temp/$name'-m 'Temperature Prop'
mosquitto_pub -t 'homie/device/temperature/temp/$unit'-m '°C'
mosquitto_pub -t 'homie/device/temperature/temp/$datatype'-m 'float'
mosquitto_pub -t 'homie/device/temperature/temp/$settable'-m 'false'
```

The first value will set as string. All subsquent messages are set as `Number`.
This can be observed in the logs, when the device's property is added.
```
mosquitto_pub -t 'homie/device/temperature/temp'-m '25.79'
```